### PR TITLE
add framework :: matplotlib classifier to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup_kwargs = {
     'maintainer': None,
     'maintainer_email': None,
     'url': None,
+    'classifiers': ['Framework :: Matplotlib'],
     'package_dir': package_dir,
     'packages': packages,
     'package_data': package_data,


### PR DESCRIPTION
Hello, saw your PR on https://github.com/matplotlib/mpl-third-party/pull/131 and checked the setup.py file and didn't see classifiers, so added the 'Framework :: matplotlib' because it's recommended alongside the listing as a third party. 

https://matplotlib.org/3.4.3/thirdpartypackages/index.html